### PR TITLE
Increase the limit of command length to 4096 bytes

### DIFF
--- a/include/Telemetrix4RpiPico.h
+++ b/include/Telemetrix4RpiPico.h
@@ -208,13 +208,13 @@ extern void set_format_spi();
 
 // spi write blocking offsets
 // #define SPI_PORT 1
-#define SPI_WRITE_LEN 2
-#define SPI_WRITE_DATA 3
+#define SPI_WRITE_LEN 2 // 16bit uint number 2 and 3 is length info
+#define SPI_WRITE_DATA 4
 
 // spi read blocking offsets
 // #define SPI_PORT 1
-#define SPI_READ_LEN 2
-#define SPI_REPEATED_DATA 3
+#define SPI_READ_LEN 2 // 16bit uint number 2 and 3 is length info
+#define SPI_REPEATED_DATA 4
 
 // spi chipselect command offsets
 #define SPI_SELECT_PIN 1
@@ -393,7 +393,8 @@ const uint DHT_MAX_TIMINGS = 85;
 #define FIRMWARE_MINOR 1
 
 // maximum length of a command packet in bytes
-#define MAX_COMMAND_LENGTH 30
+#define MAX_COMMAND_LENGTH 4096
+#define COMMAND_HEADER_LENGTH 4
 
 
 // Indicator that no i2c register is being specified in the command


### PR DESCRIPTION
- Increase command buffer to 4096 bytes (MAX_COMMAND_LENGTH)
- Use 2 bytes to store data length (SPI_WRITE_LEN)
- After sent a large buffer (512 bytes), getchar_timeout_us failed to receive data so used getchar() instead

Related to https://github.com/MrYsLab/Telemetrix4RpiPico/issues/11